### PR TITLE
Fix not able to show correct label for 0 episode for myself site

### DIFF
--- a/AniGamer/AniGamerDownloader.csproj
+++ b/AniGamer/AniGamerDownloader.csproj
@@ -114,6 +114,8 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Compile Include="Module\AesGcm.cs" />
+    <Compile Include="Module\EpisodeInfo.cs" />
+    <Compile Include="Module\SeasonInfo.cs" />
     <Compile Include="Module\DPAPI.cs" />
     <Compile Include="Module\HAnimeRequest.cs" />
     <Compile Include="Module\MyselfRequest.cs" />

--- a/AniGamer/Module/EpisodeInfo.cs
+++ b/AniGamer/Module/EpisodeInfo.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AniGamer.Module
+{
+    class EpisodeInfo
+    {
+        public readonly String DisplayName;
+        public readonly String Id;
+        public EpisodeInfo(String id, String displayName)
+        {
+            this.Id = id;
+            this.DisplayName = displayName;
+        }
+    }
+}

--- a/AniGamer/Module/SeasonInfo.cs
+++ b/AniGamer/Module/SeasonInfo.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AniGamer.Module
+{
+    class SeasonInfo
+    {
+        public readonly String Id;
+        public readonly String DisplayName;
+        public readonly List<EpisodeInfo> Episodes;
+        public SeasonInfo(String id, String displayName)
+        {
+            this.Id = id;
+            this.DisplayName = displayName;
+            this.Episodes = new List<EpisodeInfo>();
+        }
+    }
+}

--- a/AniGamer/WPF/WPF_MainForm.xaml
+++ b/AniGamer/WPF/WPF_MainForm.xaml
@@ -143,7 +143,11 @@
                     <TextBlock x:Name="TB_Title" HorizontalAlignment="Left" VerticalAlignment="Top" Margin="32,80,0,0" Text=""/>
                     <StackPanel x:Name="Grid_List" Orientation="Horizontal" Margin="32,110,0,0">
                         <ListBox x:Name="ListBox_話" BorderThickness="0" SelectionMode="Single" Visibility="Collapsed">
-                            
+                            <ListBox.ItemContainerStyle>
+                                <Style TargetType="ListBoxItem">
+                                    <Setter Property="HorizontalContentAlignment" Value="Stretch"></Setter>
+                                </Style>
+                            </ListBox.ItemContainerStyle>
                         </ListBox>
                         <DataGrid x:Name="DataGrid_清單" FontSize="15" BorderThickness="0" CanUserAddRows="False" CanUserReorderColumns="False" HeadersVisibility="Column" CanUserResizeColumns="False"  SelectionMode="Single" AutoGenerateColumns="False" HorizontalScrollBarVisibility="Disabled" Focusable="False" CanUserResizeRows="False" GridLinesVisibility="None" Background="{x:Null}" IsTabStop="False" IsReadOnly="True" HorizontalAlignment="Left" Margin="0,0,0,0" Width="912">
                             <DataGrid.Resources>

--- a/AniGamer/WPF/WPF_MainForm.xaml.cs
+++ b/AniGamer/WPF/WPF_MainForm.xaml.cs
@@ -19,6 +19,7 @@ using System.Net;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using System.Security.Cryptography;
+using AniGamer.Module;
 
 namespace WPF
 {
@@ -339,19 +340,20 @@ namespace WPF
                         }
 
 
-                        List<String> Lists = MyselfRequest.GetTitle(s);
-                        TB_Title.Text = Lists[0];
-                        if (Lists.Count > 1)
+                        SeasonInfo season = MyselfRequest.GetTitle(s);
+                        TB_Title.Text = season.DisplayName;
+                        if (season.Episodes.Count > 0)
                         {
                             ListBox_話.Items.Clear();
-                            for (int i = 1; i < Lists.Count; i++)
+                            foreach (EpisodeInfo episode in season.Episodes)
                             {
                                 Button button = new Button
                                 {
-                                    Tag = Lists[i],
-                                    Content = "第" + i.ToString() + "話",
+                                    Tag = season.Id + ":" + episode.Id,
+                                    Content = episode.DisplayName,
                                     Style = this.FindResource("Button_Span") as Style
                                 };
+                                button.HorizontalContentAlignment = HorizontalAlignment.Left;
                                 button.Click += Button_Click1;
                                 ListBox_話.Items.Add(button);
                             }


### PR DESCRIPTION
- For myself.bbs, episode 0 will have ID `013` (if there are episode 0 ~ 12), and the UI will incorrectly show the episode 0 as 13th episode.
- Make all the episode buttons have the same width
Snapshot:
![image](https://user-images.githubusercontent.com/539874/136652461-f03bbc94-d8f7-4ceb-a97f-ef3045f3a27e.png)

p.s. I don't fix the filename for now. The episode will have file name like `結城友奈是勇者第二季【全13集】-013.mp4`. Maybe we should use the title + episode name (instead of episode ID) to compose the file name?